### PR TITLE
Fix sed call for parsing version tuple

### DIFF
--- a/renpy2linux.sh
+++ b/renpy2linux.sh
@@ -30,7 +30,7 @@ else
         echo "!! Could not read renpy/__init__.py -- is this a Ren'Py game?"
         exit 1
     fi
-    RENPYVER=$(grep 'version_tuple' renpy/__init__.py | head -1 | cut -d'=' -f2 | cut -d',' -f1,2,3 | sed 's/(//g' | sed 's/,/./g' | sed 's/ //g')
+    RENPYVER=$(grep 'version_tuple' renpy/__init__.py | head -1 | cut -d'=' -f2 | cut -d',' -f1,2,3 | sed 's/.*(//g' | sed 's/,/./g' | sed 's/ //g')
 fi
 echo "=> Ren'Py version: ${RENPYVER}"
 


### PR DESCRIPTION
I came across a game where the version_tuple line looked like this:

```python
    version_tuple = VersionTuple(7, 6, 0, vc_version)
```

This caused `RENPYVER` to be parsed as `VersionTuple7.6.0`. Changing the sed command fixes this. I don't think this change should cause any regressions.